### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.1.6
           args: --timeout=3m
   go-test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
           args: --timeout=3m

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,9 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.1.6
           args: --timeout=3m
   go-test:
     strategy:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
           args: --timeout=3m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,105 +1,111 @@
-linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
-
-  gocritic:
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        skipRecvDeref: false
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment # too strict
-      - shadow # complains too much about shadowing errors. All research points to this being fine.
-
-  nakedret:
-    max-func-lines: 0
-
-  nolintlint:
-    allow-no-explanation: [ forbidigo, tracecheck, gomnd, gochecknoinits, makezero ]
-    require-explanation: true
-    require-specific: true
-
-  revive:
-    ignore-generated-header: true
-    severity: error
-    rules:
-      - name: atomic
-      - name: line-length-limit
-        arguments: [ 200 ]
-      # These are functions that we use without checking the errors often. Most of these can't return an error even
-      # though they implement an interface that can.
-      - name: unhandled-error
-        arguments:
-          - fmt.Printf
-          - fmt.Println
-          - fmt.Fprintf
-          - fmt.Fprintln
-          - os.Stderr.Sync
-          - sb.WriteString
-          - buf.WriteString
-          - hasher.Write
-          - os.Setenv
-          - os.RemoveAll
-      - name: var-naming
-        arguments: [["ID", "URL", "HTTP", "API"], []]
-
-  tenv:
-    all: true
-
-  varcheck:
-    exported-fields: false # this appears to improperly detect exported variables as unused when they are used from a package with the same name
-
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    - gosimple # Linter for Go source code that specializes in simplifying a code
-    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # Detects when assignments to existing variables are not used
-    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    - unused # Checks Go code for unused constants, variables, functions and types
-    - asasalint # Check for pass []any as any in variadic func(...any)
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - bidichk # Checks for dangerous unicode character sequences
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - durationcheck # check for two durations multiplied together
-    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
-    - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
-    - forbidigo # Forbids identifiers
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - goconst # Finds repeated strings that could be replaced by a constant
-    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
-    - godot # Check if comments end in a period
-    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
-    - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - goprintffuncname # Checks that printf-like functions are named with f at the end
-    - gosec # Inspects source code for security problems
-    - nakedret # Finds naked returns in functions greater than a specified function length
-    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
-    - noctx # noctx finds sending http request without context.Context
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - nonamedreturns # Reports all named returns
-    - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL.
-    - predeclared # find code that shadows one of Go's predeclared identifiers
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
-    - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
-    - unconvert # Remove unnecessary type conversions
-    - usestdlibvars # detect the possibility to use variables/constants from the Go standard library
-    - whitespace # Tool for detection of leading and trailing whitespace
-
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - durationcheck
+    - errcheck
+    - errorlint
+    - exhaustive
+    - forbidigo
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - godot
+    - gomoddirectives
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - nakedret
+    - nilerr
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosprintfhostport
+    - predeclared
+    - revive
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unused
+    - usestdlibvars
+    - whitespace
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
+    gocritic:
+      settings:
+        underef:
+          skipRecvDeref: false
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    nakedret:
+      max-func-lines: 0
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-no-explanation:
+        - forbidigo
+        - tracecheck
+        - gomnd
+        - gochecknoinits
+        - makezero
+    revive:
+      severity: error
+      rules:
+        - name: atomic
+        - name: line-length-limit
+          arguments:
+            - 200
+        - name: unhandled-error
+          arguments:
+            - fmt.Printf
+            - fmt.Println
+            - fmt.Fprintf
+            - fmt.Fprintln
+            - os.Stderr.Sync
+            - sb.WriteString
+            - buf.WriteString
+            - hasher.Write
+            - os.Setenv
+            - os.RemoveAll
+        - name: var-naming
+          arguments:
+            - - ID
+              - URL
+              - HTTP
+              - API
+            - []
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - godot
+        source: (TODO)
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-same-issues: 50
-
-  exclude-rules:
-    # Don't require TODO comments to end in a period
-    - source: "(TODO)"
-      linters: [ godot ]
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/baton-galileo-ft/main.go
+++ b/cmd/baton-galileo-ft/main.go
@@ -23,6 +23,7 @@ const (
 	apiTransKey   = "api-trans-key"
 	providerID    = "provider-id"
 	hostname      = "hostname"
+	baseURL       = "base-url"
 )
 
 var (
@@ -38,14 +39,18 @@ var (
 	)
 	hostnameField = field.StringField(
 		hostname,
-		field.WithDescription("URL hostname for production hostname."),
+		field.WithDescription("URL hostname for production hostname (deprecated: use --base-url instead)."),
+	)
+	baseURLField = field.StringField(
+		baseURL,
+		field.WithDescription("Override the Galileo FT API URL (for testing)."),
 	)
 	providerIDField = field.StringField(
 		providerID,
 		field.WithRequired(true),
 		field.WithDescription("A unique identifier from Galileo-FT representing your organization, used for tracking transactions and data."),
 	)
-	configurationFields = []field.SchemaField{apiLoginField, apiTransKeyField, providerIDField, hostnameField}
+	configurationFields = []field.SchemaField{apiLoginField, apiTransKeyField, providerIDField, hostnameField, baseURLField}
 )
 
 func main() {
@@ -72,6 +77,7 @@ func getConnector(ctx context.Context, cfg *viper.Viper) (types.ConnectorServer,
 	l := ctxzap.Extract(ctx)
 	cb, err := connector.New(ctx, &galileo.Config{
 		Hostname:    cfg.GetString(hostname),
+		BaseURL:     cfg.GetString(baseURL),
 		APILogin:    cfg.GetString(apiLogin),
 		APITransKey: cfg.GetString(apiTransKey),
 		ProviderID:  cfg.GetString(providerID),

--- a/cmd/baton-galileo-ft/main.go
+++ b/cmd/baton-galileo-ft/main.go
@@ -44,6 +44,7 @@ var (
 	baseURLField = field.StringField(
 		baseURL,
 		field.WithDescription("Override the Galileo FT API URL (for testing)."),
+		field.WithHidden(true),
 	)
 	providerIDField = field.StringField(
 		providerID,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -57,7 +57,12 @@ func New(ctx context.Context, cfg *galileo.Config) (*Galileo, error) {
 		return nil, err
 	}
 
+	client, err := galileo.NewClient(httpClient, cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Galileo{
-		client: galileo.NewClient(httpClient, cfg),
+		client: client,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-galileo-ft/main.go,pkg/connector/connector.go,pkg/galileo/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-galileo-ft --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BaseURL configuration option for specifying server endpoints.

* **Refactor**
  * Improved error handling and validation during client initialization.

* **Deprecations**
  * Hostname configuration is now deprecated; use BaseURL instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->