### PR TITLE
fix: mark api-trans-key as isSecret in config_schema

### DIFF
--- a/cmd/baton-galileo-ft/main.go
+++ b/cmd/baton-galileo-ft/main.go
@@ -36,6 +36,7 @@ var (
 		apiTransKey,
 		field.WithRequired(true),
 		field.WithDescription("The password provided by Galileo-FT, used alongside the api-login."),
+		field.WithIsSecret(true),
 	)
 	hostnameField = field.StringField(
 		hostname,


### PR DESCRIPTION
The `api-trans-key` field is the password/transaction key provided by Galileo-FT for API access but was a plain `field.StringField` with no `field.WithIsSecret(true)`, so it was not marked secret. This adds `WithIsSecret(true)`. `api-login` (username), `provider-id`, `hostname`, and `base-url` are not secret credentials and are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

_Built with stargate._
